### PR TITLE
Use the prio field on SRV records

### DIFF
--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -80,62 +80,72 @@
     {
       "name": "_client._smtp",
       "type": "SRV",
-      "content": "1 1 1 {{domain}}",
-      "ttl": 3600
+      "content": "1 1 {{domain}}",
+      "ttl": 3600,
+      "prio": 1
     },
     {
       "name": "_submission._tcp",
       "type": "SRV",
-      "content": "0 1 587 smtp.fastmail.com",
-      "ttl": 3600
+      "content": "1 587 smtp.fastmail.com",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_imap._tcp",
       "type": "SRV",
-      "content": "0 0 0 .",
-      "ttl": 3600
+      "content": "0 0 .",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_imaps._tcp",
       "type": "SRV",
-      "content": "0 1 993 imap.fastmail.com",
-      "ttl": 3600
+      "content": "1 993 imap.fastmail.com",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_pop3._tcp",
       "type": "SRV",
-      "content": "0 0 0 .",
-      "ttl": 3600
+      "content": "0 0 .",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_pop3s._tcp",
       "type": "SRV",
-      "content": "10 1 995 pop.fastmail.com",
-      "ttl": 3600
+      "content": "1 995 pop.fastmail.com",
+      "ttl": 3600,
+      "prio": 10
     },
     {
       "name": "_carddav._tcp",
       "type": "SRV",
-      "content": "0 0 0 .",
-      "ttl": 3600
+      "content": "0 0 .",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_carddavs._tcp",
       "type": "SRV",
-      "content": "0 1 443 carddav.fastmail.com",
-      "ttl": 3600
+      "content": "1 443 carddav.fastmail.com",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_caldav._tcp",
       "type": "SRV",
-      "content": "0 0 0 .",
-      "ttl": 3600
+      "content": "0 0 .",
+      "ttl": 3600,
+      "prio": 0
     },
     {
       "name": "_caldavs._tcp",
       "type": "SRV",
-      "content": "0 1 443 caldav.fastmail.com",
-      "ttl": 3600
+      "content": "1 443 caldav.fastmail.com",
+      "ttl": 3600,
+      "prio": 0
     }
   ]
 }


### PR DESCRIPTION
Since we set the priority of a record separately from the content, this
change adds the prio field to all uses of an SRV record in the Fastmail
service.

@sbastn does this look good to you?