### PR TITLE
Office365 SRV records

### DIFF
--- a/services/office-365/config.json
+++ b/services/office-365/config.json
@@ -75,14 +75,16 @@
     },
     {
       "name": "_sip._tls",
-      "content": "100 1 443 sipdir.online.lync.com",
+      "content": "1 443 sipdir.online.lync.com",
       "type": "SRV",
+      "prio": 100,
       "ttl": 3600
     },
     {
       "name": "_sipfederationtls._tcp",
-      "content": "100 1 5061 sipfed.online.lync.com",
+      "content": "1 5061 sipfed.online.lync.com",
       "type": "SRV",
+      "prio": 100,
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
This PR separates the priority field from the content for the SRV records on the Office 365 service. Like we did on #55.

@jcaudle I tested this locally and it works as expected, but can I have your 👀 on this?