### PR TITLE
Heroku update

### DIFF
--- a/services/heroku-ssl/config.json
+++ b/services/heroku-ssl/config.json
@@ -3,7 +3,8 @@
     "name": "heroku-ssl",
     "label": "Heroku SSL",
     "description": "Use Heroku as your web host, with SSL support.",
-    "category": "infrastructure"
+    "category": "infrastructure",
+    "deprecated": true
   },
   "fields": [
     {

--- a/services/heroku/config.json
+++ b/services/heroku/config.json
@@ -17,13 +17,13 @@
   "records": [
     {
       "type": "ALIAS",
-      "content": "{{app}}.herokuapp.com",
+      "content": "{{app}}.herokudns.com",
       "ttl": 3600
     },
     {
       "name": "www",
       "type": "CNAME",
-      "content": "{{app}}.herokuapp.com",
+      "content": "{{app}}.herokudns.com",
       "ttl": 3600
     }
   ]


### PR DESCRIPTION
Update the Heroku configuration based on #60 and deprecates the existing Heroku SSL configuration since it is no longer needed.