### PR TITLE
Updating fast mail config with DKIM cnames

### DIFF
--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -61,10 +61,22 @@
       "ttl": 3600
     },
     {
-      "name": "mesmtp._domainkey",
-      "type": "TXT",
-      "content": "{{dkim}}",
-      "ttl": 3600
+      "name": "fm1._domainkey.{{domain}}",
+      "type": "CNAME",
+      "content": "fm1.{{domain}}.dkim.fmhosted.com",
+      "ttl": 3600 
+    },
+    {
+      "name": "fm2._domainkey.{{domain}}",
+      "type": "CNAME",
+      "content": "fm2.{{domain}}.dkim.fmhosted.com",
+      "ttl": 3600 
+    },
+    {
+      "name": "fm3._domainkey.{{domain}}",
+      "type": "CNAME",
+      "content": "fm3.{{domain}}.dkim.fmhosted.com",
+      "ttl": 3600 
     },
     {
       "name": "_adsp._domainkey",
@@ -74,7 +86,7 @@
     },
     {
       "type": "SPF",
-      "content": "v=spf1 include:spf.messagingengine.com ~all",
+      "content": "v=spf1 include:spf.messagingengine.com ?all",
       "ttl": 3600
     },
     {

--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -53,24 +53,24 @@
       "ttl": 3600
     },
     {
-      "name": "fm1._domainkey.{{domain}}",
+      "name": "fm1._domainkey",
       "type": "CNAME",
       "content": "fm1.{{domain}}.dkim.fmhosted.com",
-      "ttl": 3600 
+      "ttl": 3600
     },
     {
-      "name": "fm2._domainkey.{{domain}}",
+      "name": "fm2._domainkey",
       "type": "CNAME",
       "content": "fm2.{{domain}}.dkim.fmhosted.com",
-      "ttl": 3600 
+      "ttl": 3600
     },
     {
-      "name": "fm3._domainkey.{{domain}}",
+      "name": "fm3._domainkey",
       "type": "CNAME",
       "content": "fm3.{{domain}}.dkim.fmhosted.com",
-      "ttl": 3600 
+      "ttl": 3600
     },
-    {
+      {
       "type": "SPF",
       "content": "v=spf1 include:spf.messagingengine.com ~all",
       "ttl": 3600

--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -86,7 +86,7 @@
     },
     {
       "type": "SPF",
-      "content": "v=spf1 include:spf.messagingengine.com ?all",
+      "content": "v=spf1 include:spf.messagingengine.com ~all",
       "ttl": 3600
     },
     {

--- a/services/fastmail/config.json
+++ b/services/fastmail/config.json
@@ -5,14 +5,6 @@
     "description": "Email, calendars and contacts done right.",
     "category": "email"
   },
-  "fields": [
-    {
-      "name": "dkim",
-      "label": "DKIM Key",
-      "description": "Enter the contents of the DKIM record as provided on Fastmail's Domain Settings page for this domain.",
-      "example": "v=DKIM1; k=rsa; p=..."
-    }
-  ],
   "records": [
     {
       "type": "MX",
@@ -77,12 +69,6 @@
       "type": "CNAME",
       "content": "fm3.{{domain}}.dkim.fmhosted.com",
       "ttl": 3600 
-    },
-    {
-      "name": "_adsp._domainkey",
-      "type": "TXT",
-      "content": "dkim=unknown",
-      "ttl": 3600
     },
     {
       "type": "SPF",


### PR DESCRIPTION
This PR is in service of this customer support request https://twitter.com/sandfoxthat/status/846298207747543040

There is no blog post update in fastmail on what has changed, so I needed to find the changes on their help section. I'm certainly sure that the only changes come in the DKIM, with three new CNAMES and one old. I have found the changes in this support article: https://www.fastmail.com/help/receive/domains-advanced.html#dnslist

I just need another pair of eyes here to confirm that the changes are good before I ship.